### PR TITLE
Removing legacy icon-precomposed and updating path

### DIFF
--- a/templates/partials/base.html
+++ b/templates/partials/base.html
@@ -28,7 +28,7 @@
     <meta name="viewport" content="width=device-width">
 
     <link rel="shortcut icon" href="/static/images/favicon.png">
-    <link rel="apple-touch-icon icon-precomposed" href="/static/images/apple-touch-icon.png"/>
+    <link rel="apple-touch-icon" href="/static/images/touch-icon.png">
 
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/normalize/3.0.0/normalize.min.css">
 


### PR DESCRIPTION
This is no longer needed and can actually cause issues on some devices to fail at loading the touch icon on the home screen. This change also updates the path to the correct touch-icon.
