### PR TITLE
dirty filter hack to add class to markdown image block

### DIFF
--- a/libs/swig_filters.js
+++ b/libs/swig_filters.js
@@ -511,6 +511,18 @@ module.exports.init = function (swig) {
     return suffix;
   }
 
+  // Down and dirty hack for image classes
+  // ![Real Alt Text|class1 class2 class3](src)
+  // 
+  var mdAltClass = function (input) {
+    var re = /(<img.*)?alt=(['"](.*?)\|(.*?)['"])(.*>)/;
+    var result = "";
+    input.split('\n').forEach(function(e,i) {
+      result += e.replace(re,"$1 alt=\"$3\" class=\"$4\" ");
+    });
+    return result;
+  }
+
   markdown.safe = true;
   linebreaks.safe = true;
   jsonP.safe = true;
@@ -537,4 +549,5 @@ module.exports.init = function (swig) {
   swig.setFilter('pluralize', pluralize);
   swig.setFilter('jsonp', jsonP);
   swig.setFilter('json', json);
+  swig.setFilter('mdAltClass, mdAltClass');
 };


### PR DESCRIPTION
This is a very simple filter that iterates each line of text and mangles ```alt="this is the alt|classes here"``` into ```alt="this is the alt" class="classes here"```, eg:

```{{ item.content | markdown | imgAltClass }}```

Ideally, and IMO, marked should be replaced with something that supports Markdown Extras, so you can use the ```{.class key=val}``` stuff, but I think this will suffice for now.